### PR TITLE
监听逻辑重构

### DIFF
--- a/ZFPlayer/ZFPlayerView.m
+++ b/ZFPlayer/ZFPlayerView.m
@@ -145,8 +145,11 @@ static ZFPlayerView* playerView = nil;
 - (void)dealloc
 {
     //NSLog(@"%@释放了",self.class);
-    // 移除所有通知、观察者
+
     self.playerItem = nil;
+    self.tableView = nil;
+
+    // 移除所有通知
     [self removeNotifications];
 }
 
@@ -217,40 +220,17 @@ static ZFPlayerView* playerView = nil;
     [self.controlView.fullScreenBtn addTarget:self action:@selector(fullScreenAction:) forControlEvents:UIControlEventTouchUpInside];
     // 锁定屏幕方向点击事件
     [self.controlView.lockBtn addTarget:self action:@selector(lockScreenAction:) forControlEvents:UIControlEventTouchUpInside];
-    
-    // 添加Tableview观察者
-    [self addTableViewObserver];
+
     // 监测设备方向
     [self listeningRotating];
 }
 
 /**
- *  移除所有通知、观察者
+ *  移除所有通知
  */
 - (void)removeNotifications {
     // 移除通知
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    // 移除观察者
-    [self removeTableViewObserver];
-}
-
-/**
- *  添加Tableview观察者
- */
-- (void)addTableViewObserver {
-    if (self.tableView) {
-        // 监听tab偏移量
-        [self.tableView addObserver:self forKeyPath:kZFPlayerViewContentOffset options:NSKeyValueObservingOptionNew context:nil];
-    }
-}
-
-/**
- *  移除TableView观察者
- */
-- (void)removeTableViewObserver {
-    if (self.tableView) {
-        [self.tableView removeObserver:self forKeyPath:kZFPlayerViewContentOffset];
-    }
 }
 
 /**
@@ -1429,6 +1409,18 @@ static ZFPlayerView* playerView = nil;
         [playerItem addObserver:self forKeyPath:@"playbackBufferEmpty" options:NSKeyValueObservingOptionNew context:nil];
         // 缓冲区有足够数据可以播放了
         [playerItem addObserver:self forKeyPath:@"playbackLikelyToKeepUp" options:NSKeyValueObservingOptionNew context:nil];
+    }
+}
+
+- (void)setTableView:(UITableView *)tableView {
+    if (_tableView == tableView) return;
+
+    if (_tableView) {
+        [_tableView removeObserver:self forKeyPath:kZFPlayerViewContentOffset];
+    }
+    _tableView = tableView;
+    if (tableView) {
+        [tableView addObserver:self forKeyPath:kZFPlayerViewContentOffset options:NSKeyValueObservingOptionNew context:nil];
     }
 }
 


### PR DESCRIPTION
现在的代码不支持连续设置 videoURL 来切换视频，每次切换都必须重置，否则会因为 KVO 仍在监听已经释放的 playerItem 直接崩溃。

把逻辑跟属性绑在一起，一是集中起来便与维护了，属性是什么状态监听就是什么状态，不用考虑重复监听、会不会移除没添加的监听等杂七杂八的问题，二来可以免去一些反复执行的工作。
