### PR TITLE
解决播放过程中退到后台，或上拉出控制中心，下拉出通知中心，视频暂停 按钮没反应的问题

### DIFF
--- a/ZFPlayer/ZFPlayerView.m
+++ b/ZFPlayer/ZFPlayerView.m
@@ -1252,9 +1252,10 @@ typedef NS_ENUM(NSInteger, ZFPlayerState) {
 - (void)appDidEnterBackground
 {
     self.didEnterBackground = YES;
-    [self pause];
+    [_player pause];
     self.state = ZFPlayerStatePause;
     [self cancelAutoFadeOutControlBar];
+    self.controlView.startBtn.selected = NO;
 }
 
 /**


### PR DESCRIPTION
@renzifeng 非常感谢你写了如此优秀的播放器，用着很顺手。
发现一个小问题，在视频播放过程中退到后台/上拉出控制中心/下拉出通知中心时，视频暂停了，应用回到前台后 没有继续播放，播放按钮的状态没有改变。看了下你的代码，稍微修改了下，谢谢。