### PR TITLE
Fix crash while totalMovieDuration is zero

### DIFF
--- a/ZFPlayer/Classes/ControlView/ZFPlayerControlView.m
+++ b/ZFPlayer/Classes/ControlView/ZFPlayerControlView.m
@@ -308,6 +308,7 @@ static const CGFloat ZFPlayerControlViewAutoFadeOutTimeInterval = 0.25f;
         if (velocity.x > 0) { style = YES; }
         if (velocity.x < 0) { style = NO; }
         if (velocity.x == 0) { return; }
+        if (totalMovieDuration == 0) { return; }
         [self sliderValueChangingValue:self.sumTime/totalMovieDuration isForward:style];
     } else if (direction == ZFPanDirectionV) {
         if (location == ZFPanLocationLeft) { /// 调节亮度


### PR DESCRIPTION
当` totalMovieDuration` 为0 时需要提前退出，否则作为除数会导致crash。