### PR TITLE
fix 倍速播放断断续续的问题

### DIFF
--- a/ZFPlayer/Classes/AVPlayer/ZFAVPlayerManager.m
+++ b/ZFPlayer/Classes/AVPlayer/ZFAVPlayerManager.m
@@ -371,9 +371,9 @@ static NSString *const kPresentationSize         = @"presentationSize";
             // When the buffer is good
             if (self.playerItem.playbackLikelyToKeepUp) {
                 self.loadState = ZFPlayerLoadStatePlayable;
+                if (self.isPlaying) [self play];
             }
         } else if ([keyPath isEqualToString:kLoadedTimeRanges]) {
-            if (self.isPlaying && self.playerItem.playbackLikelyToKeepUp) [self play];
             NSTimeInterval bufferTime = [self availableDuration];
             self->_bufferTime = bufferTime;
             if (self.playerBufferTimeChanged) self.playerBufferTimeChanged(self, bufferTime);


### PR DESCRIPTION
KVO 监听 `AVPlayerItem.loadedTimeRanges` 调用多次，每次缓存数据变化都会调用。且 `AVPlayerItem` 的 `playbackLikelyToKeepUp` 为 true 时，AVPlayer 的 `rate` 会变为 1.0。如果在 `AVPlayerItem.loadedTimeRanges` 中频繁调用播放方法，设置 rate 为其他倍速参数。会导致 rate 在 1.0 和其他参数之间来回切换，导致倍速断断续续。[详情查看 WWDC2016 session 503](https://developer.apple.com/videos/play/wwdc2016/503/)