### PR TITLE
fix: 修复 coverImageView 没有实现的问题

### DIFF
--- a/ZFPlayer/Classes/ControlView/ZFPlayerControlView.h
+++ b/ZFPlayer/Classes/ControlView/ZFPlayerControlView.h
@@ -62,9 +62,6 @@
 /// 底部播放进度
 @property (nonatomic, strong, readonly) ZFSliderView *bottomPgrogress;
 
-/// 封面图
-@property (nonatomic, strong, readonly) UIImageView *coverImageView;
-
 /// 高斯模糊的背景图
 @property (nonatomic, strong, readonly) UIImageView *bgImgView;
 


### PR DESCRIPTION
在 https://github.com/renzifeng/ZFPlayer/commit/6e46f6a3595a4b6e1c2c8293e94e687e5b84d36f#diff-fb60d03bfefdec700c3aef205f634cadc12db5a8dc711351eacb4fa8435f40c9L61 里只删除了 `.m` 文件里 `coverImageView` 的声明和实现，漏了 `.h` 里的声明。