### PR TITLE
修复ZFIJKPlayerManager调用reloadPlayer或重复调用prepareToPlay导致重复播放同一资源并永远无法释放的问题

### DIFF
--- a/ZFPlayer/Classes/ijkplayer/ZFIJKPlayerManager.m
+++ b/ZFPlayer/Classes/ijkplayer/ZFIJKPlayerManager.m
@@ -160,6 +160,14 @@
 #pragma mark - private method
 
 - (void)initializePlayer {
+    // IJKFFMoviePlayerController 初始化后，必须手动进行释放，否则会依然存在内存中对资源进行播放。
+    if (self.player) {
+        [self removeMovieNotificationObservers];
+        [self.player shutdown];
+        [self.player.view removeFromSuperview];
+        self.player = nil;
+    }
+
     self.player = [[IJKFFMoviePlayerController alloc] initWithContentURL:self.assetURL withOptions:self.options];
     self.player.shouldAutoplay = self.shouldAutoPlay;
     [self.player prepareToPlay];


### PR DESCRIPTION
播放RTMP的直播音频流时，对`ZFIJKPlayerManager`实例调用`reloadPlayer`或者重复调用`prepareToPlay`时，会出现重复播放并无法释放的情况。检查发现是这两个方法均会调用`initializePlayer`重新创建`IJKFFMoviePlayerController`，`IJKFFMoviePlayerController`实例在置为nil后并不会释放，导致内存中同时存在多个`IJKFFMoviePlayerController`实例播放同一个音频。