### PR TITLE
修复seek之后，视频播放，进度条不走的问题

### DIFF
--- a/ZFPlayer/Classes/ControlView/ZFLandScapeControlView.m
+++ b/ZFPlayer/Classes/ControlView/ZFLandScapeControlView.m
@@ -231,8 +231,8 @@
         @zf_weakify(self)
         [self.player seekToTime:self.player.totalTime*value completionHandler:^(BOOL finished) {
             @zf_strongify(self)
+            self.slider.isdragging = NO;
             if (finished) {
-                self.slider.isdragging = NO;
                 if (self.sliderValueChanged) self.sliderValueChanged(value);
                 if (self.seekToPlay) {
                     [self.player.currentPlayerManager play];

--- a/ZFPlayer/Classes/ControlView/ZFPortraitControlView.m
+++ b/ZFPlayer/Classes/ControlView/ZFPortraitControlView.m
@@ -188,8 +188,8 @@
         @zf_weakify(self)
         [self.player seekToTime:self.player.totalTime*value completionHandler:^(BOOL finished) {
             @zf_strongify(self)
+            self.slider.isdragging = NO;
             if (finished) {
-                self.slider.isdragging = NO;
                 if (self.sliderValueChanged) self.sliderValueChanged(value);
             }
         }];


### PR DESCRIPTION
- (void)seekToTime:(CMTime)time toleranceBefore:(CMTime)toleranceBefore toleranceAfter:(CMTime)toleranceAfter completionHandler:(void (^)(BOOL finished))completionHandler
当拖拽slider最终会调用上面方法进行seek，如果这个时候因为网络原因需要缓冲，调用了bufferingSomeSecond方法，这个方法里会调用player的pause和play，这样系统会立刻取消掉seek，上面方法的completionHandler block会返回false，这样slider的isdragging无法重置回NO，导致视频播放，进度不走