### PR TITLE
修复iOS16退出全屏后LandscapeWindow停留页面阻挡交互

### DIFF
--- a/ZFPlayer/Classes/Core/ZFLandscapeRotationManager_iOS16.m
+++ b/ZFPlayer/Classes/Core/ZFLandscapeRotationManager_iOS16.m
@@ -58,15 +58,7 @@
     CGFloat minSize = MIN(screenBounds.size.width, screenBounds.size.height);
   
     self.contentView.autoresizingMask = UIViewAutoresizingNone;
-    if (fromOrientation == UIInterfaceOrientationPortrait || self.contentView.superview != self.landscapeViewController.view) {
-        self.contentView.frame = sourceFrame;
-        [sourceWindow addSubview:self.contentView];
-        [self.contentView layoutIfNeeded];
-        if (!self.window.isKeyWindow) {
-            self.window.hidden = NO;
-            [self.window makeKeyAndVisible];
-        }
-    } else if (toOrientation == UIInterfaceOrientationPortrait) {
+    if (toOrientation == UIInterfaceOrientationPortrait) {
         self.contentView.bounds = CGRectMake(0, 0, maxSize, minSize);
         self.contentView.center = CGPointMake(minSize * 0.5, maxSize * 0.5);
         self.contentView.transform = [self getRotationTransform:fromOrientation];
@@ -74,6 +66,14 @@
         [sourceWindow makeKeyAndVisible];
         [self.contentView layoutIfNeeded];
         self.window.hidden = YES;
+    } else if (fromOrientation == UIInterfaceOrientationPortrait || self.contentView.superview != self.landscapeViewController.view) {
+        self.contentView.frame = sourceFrame;
+        [sourceWindow addSubview:self.contentView];
+        [self.contentView layoutIfNeeded];
+        if (!self.window.isKeyWindow) {
+            self.window.hidden = NO;
+            [self.window makeKeyAndVisible];
+        }
     }
     [self setNeedsUpdateOfSupportedInterfaceOrientations];
 


### PR DESCRIPTION
首先感谢大佬的辛苦付出，这个库用了很多年了，帮助非常多，白嫖这么多年从不提pr，这次希望能为维护这个库略尽绵薄之力。
如下是这次遇到问题的具体情况：

### 设备
iPhone 12 Pro Max，iOS 16.1.1

### 问题
播放器退出全屏后，界面无法交互，检查图层发现是LandscapeWindow未隐藏，定位代码确定是退出全屏时ZFLandscapeRotationManager_iOS16中所修改代码段中获取的fromOrientation、toOrientation都为UIInterfaceOrientationPortrait，导致进入错误的逻辑，LandscapeWindow未执行隐藏逻辑
[代码截图](http://pic.cyfuer.top/images/2022/11/19/WeChat5b7b6714d73ba541c9571764bc368320.md.png)

### 解决
- 以下两个判断条件理论是完全互斥关系，可任意调整位置
- fromOrientation存在不准确的可能，toOrientation为强主观逻辑变量，优先判断toOrientation更准确 
- 在不影响逻辑优先度的情况下短路径放前面也更好一点

基于以上3点原因建议调换判断条件的位置：

> if (fromOrientation == UIInterfaceOrientationPortrait || self.contentView.superview != self.landscapeViewController.view) {
        ...
    } else if (toOrientation == UIInterfaceOrientationPortrait) {
        ...
    }